### PR TITLE
botname 설정 & massage => message 오타 수정

### DIFF
--- a/workingTimeMemo/work.py
+++ b/workingTimeMemo/work.py
@@ -105,12 +105,14 @@ def define_command_func(command, event):
         select_channel_DM(channel, notDefineCommand)
 
 
-def select_channel_DM(channel, massage):
+def select_channel_DM(channel, message):
     # Sends the response back to the channel
     slack_client.api_call(
         "chat.postMessage",
+        # botname 설정 & massage => message 오타 수정
+        username='hansonbot',
         channel=channel,
-        text=massage
+        text=message
     )
 
 


### PR DESCRIPTION
issue
- "bot"으로 슬랙채널에서 메시지를 보내는데 봇 이름을 따로 바꿔서 메시지를 보낼 수 없었음
- 'massage' 오타
